### PR TITLE
Fixed overlap problem on last merge from delton-develop

### DIFF
--- a/UserInterface/css/home.css
+++ b/UserInterface/css/home.css
@@ -114,8 +114,9 @@ main {
   background-color: #eeeeee;
 }
 
+/* Text Clamp for Room Name h2 */
 .text-clamp {
-  font-size: clamp(2.7rem, 2.5vw, 3rem);
+  font-size: clamp(2.7rem, 2.5vw, 3rem); 
 }
 
 

--- a/UserInterface/css/home.css
+++ b/UserInterface/css/home.css
@@ -99,11 +99,11 @@ main {
   border-radius: 15px;
   border-color: #07ad90;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
-  margin: auto; 
   padding: 20px;
   text-align: center;
   cursor: pointer;
-  animation: blink ;
+  animation: blink;
+  box-sizing: border-box; /* Include padding and border in the width calculation */
 }
 .room-card img {
   max-width: 100%;
@@ -114,6 +114,9 @@ main {
   background-color: #eeeeee;
 }
 
+.text-clamp {
+  font-size: clamp(2.7rem, 2.5vw, 3rem);
+}
 
 
 .room-plus-card {

--- a/UserInterface/js/home.js
+++ b/UserInterface/js/home.js
@@ -136,7 +136,7 @@ export async function renderRoomCards(intervalId) {
       card_header.setAttribute('class', 'card-header');
       card_header.setAttribute('class', 'text-clamp');
       card_body.setAttribute('class', 'row');
-      roomName.setAttribute('class', 'display-3 text-clamp');
+      roomName.setAttribute('class', 'display-3 text-clamp'); // adding text-clamp property to roomName
       roomName.setAttribute('style', 'color: grey');
             
       // Get agent 

--- a/UserInterface/js/home.js
+++ b/UserInterface/js/home.js
@@ -134,8 +134,9 @@ export async function renderRoomCards(intervalId) {
       
       // roomAlive.setAttribute('style', 'color: green');
       card_header.setAttribute('class', 'card-header');
+      card_header.setAttribute('class', 'text-clamp');
       card_body.setAttribute('class', 'row');
-      roomName.setAttribute('class', 'display-3');
+      roomName.setAttribute('class', 'display-3 text-clamp');
       roomName.setAttribute('style', 'color: grey');
             
       // Get agent 


### PR DESCRIPTION
Solution rundown: 
- I added a `.text-clamp` class to the h2 in the room cards. This sets the text size to dynamically change one different sized screens so we don't have text overflow. 
- Added `grid-template-columns ` property using the repeat() to spread out the room cards by using autofit and a minmax() method. Helps with viewing on all devices. 