### PR TITLE
fixed password staying white in light mode

### DIFF
--- a/UserInterface/css/style.css
+++ b/UserInterface/css/style.css
@@ -637,7 +637,11 @@ textarea {
   color: #ffffff;
 }
 
-.dark-mode .face .content .field-wrapper input[type=text], .face .content .field-wrapper input[type=password], .face .content .field-wrapper textarea{
+/* .dark-mode .face .content .field-wrapper input[type=text], .face .content .field-wrapper input[type=password], .face .content .field-wrapper textarea{
+  color: #ffffff;
+} */
+
+.dark-mode .face .content .field-wrapper input[type=text],.dark-mode .face .content .field-wrapper input[type=password]{
   color: #ffffff;
 }
 .form-switch {


### PR DESCRIPTION
forgot to add dark-mode to the input[type=password]. This was why it wasn't applying in light mode